### PR TITLE
Fix float errors — No tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ class Cashify {
 	}
 
 	/**
-	* @param {number} amount Amount of money you want to convert
+	* @param {number} amount Amount of money you want to convert (in decimal, e.g., $1 = 1.00)
 	* @param {object} options Conversion options
 	* @param {string} options.from Currency from which you want to convert
 	* @param {string} options.to Currency to which you want to convert
@@ -58,12 +58,12 @@ class Cashify {
 			return amount;
 		}
 
-		return amount * getRate({base, rates, from, to});
+		return (amount * 100) * getRate({base, rates, from, to}) / 100;
 	}
 }
 
 /**
-* @param {number} amount Amount of money you want to convert
+* @param {number} amount Amount of money you want to convert (in decimal, e.g., $1 = 1.00)
 * @param {object} options Conversion options
 * @param {string} options.from Currency from which you want to convert
 * @param {string} options.to Currency to which you want to convert
@@ -77,7 +77,7 @@ const convert = (amount: number, {from, to, base, rates}: Options): number => {
 		return amount;
 	}
 
-	return amount * getRate({base, rates, from, to});
+	return (amount * 100) * getRate({base, rates, from, to}) / 100;
 };
 
 export {


### PR DESCRIPTION
This is what I described via Twitter DM, I'm not sure if I was clear there, so wanted to clarify with some code.

This means that when converting 10 Euros to GBP, with the rates of 1EUR = 0.92GBP, that we'll return 9.2 instead of 9.200000000000001 — the `00000000000001` at the end of the number has to do with the way numbers, in particular floats, are stored in JavaScript: they use double-precision 64-bit binary format IEEE 754 value.

See also: 
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number
- https://en.wikipedia.org/wiki/Floating-point_arithmetic
- https://en.wikipedia.org/wiki/Decimalisation