### PR TITLE
chore: Actually include the files in the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
     "module": "dist/index.esm.js",
     "types": "dist/index.d.ts",
     "files": [
-        "dist/index.js",
-        "dist/index.esm.js",
-        "dist/index.d.ts"
+        "dist/**/*"
     ],
     "author": "Antoni Kepinski <a@kepinski.me> (https://kepinski.me)",
     "bugs": {


### PR DESCRIPTION
This issue managed to bypass the unit tests - NPM wasn't actually publishing most of the compiled code resulting in `require` ENOENT errors.

cc @xxczaki 