### PR TITLE
when from === to === base, will throw '`rates` object does not contain either `from` or `to` currency!'

### DIFF
--- a/src/lib/get-rate.ts
+++ b/src/lib/get-rate.ts
@@ -11,6 +11,10 @@ import {Rates} from './options';
 */
 export default function getRate(base: string, rates: Rates, from: string | undefined, to: string | undefined): number {
 	if (from && to) {
+		// if `from` equals `to` return `from` directly
+		if (from === to) {
+			return from;
+		}
 		// If `from` equals `base`, return the basic exchange rate for the `to` currency
 		if (from === base && hasKey(rates, to)) {
 			return rates[to];


### PR DESCRIPTION
if `from` === `to`, return `from` directly.