### PR TITLE
If `from equals to, return 100% directly

### DIFF
--- a/src/lib/get-rate.ts
+++ b/src/lib/get-rate.ts
@@ -11,6 +11,11 @@ import {Rates} from './options';
 */
 export default function getRate(base: string, rates: Rates, from: string | undefined, to: string | undefined): number {
 	if (from && to) {
+		// If `from equals to, return 100% directly
+	    	if (from === to){
+			return 1;
+	    	}
+		
 		// If `from` equals `base`, return the basic exchange rate for the `to` currency
 		if (from === base && hasKey(rates, to)) {
 			return rates[to];


### PR DESCRIPTION
this fix when base === from === to, throw '`rates` object does not contain either `from` or `to` currency!'