### PR TITLE
Correctly handle '0' passed as string to convert()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,83 +1,83 @@
 {
-	"name": "cashify",
-	"version": "2.4.4",
-	"description": "Lightweight currency conversion library, successor of money.js",
-	"main": "dist/index.js",
-	"module": "dist/index.esm.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist/**/*"
-	],
-	"author": "Antoni Kepinski <a@kepinski.me> (https://kepinski.me)",
-	"bugs": {
-		"url": "https://github.com/xxczaki/cashify/issues"
-	},
-	"scripts": {
-		"prebuild": "del-cli dist",
-		"esm": "tsc --module esnext && cpy dist/index.js dist --rename index.esm.js",
-		"cjs": "tsc --module commonjs",
-		"build": "npm run esm && npm run cjs",
-		"test": "xo && nyc ava",
-		"prepublishOnly": "npm run build"
-	},
-	"engines": {
-		"node": ">=10"
-	},
-	"license": "MIT",
-	"repository": "xxczaki/cashify",
-	"homepage": "https://github.com/xxczaki/cashify",
-	"funding": {
-		"type": "opencollective",
-		"url": "https://opencollective.com/cashify"
-	},
-	"keywords": [
-		"cashify",
-		"cash",
-		"moneyjs",
-		"money.js",
-		"money",
-		"conversion",
-		"exchange",
-		"currency-exchange",
-		"exchange-rates",
-		"open-exchange-rates",
-		"fixer",
-		"currencies",
-		"convert-currency-rates",
-		"replacement",
-		"convert-currencies",
-		"typescript",
-		"money-conversion"
-	],
-	"devDependencies": {
-		"@akepinski/tsconfig": "0.0.2",
-		"@typescript-eslint/eslint-plugin": "^3.10.1",
-		"@typescript-eslint/parser": "^3.10.1",
-		"ava": "^3.12.1",
-		"coveralls": "^3.1.0",
-		"cpy-cli": "^3.1.1",
-		"del-cli": "^3.0.1",
-		"eslint-config-xo-typescript": "^0.32.0",
-		"nyc": "^15.1.0",
-		"ts-node": "^9.0.0",
-		"type-fest": "^0.16.0",
-		"typescript": "^4.0.2",
-		"xo": "^0.33.0"
-	},
-	"sideEffects": false,
-	"ava": {
-		"extensions": [
-			"ts"
-		],
-		"require": [
-			"ts-node/register"
-		]
-	},
-	"xo": {
-		"extends": "xo-typescript",
-		"extensions": [
-			"ts"
-		]
-	},
-	"dependencies": {}
+    "name": "cashify",
+    "version": "2.4.4",
+    "description": "Lightweight currency conversion library, successor of money.js",
+    "main": "dist/index.js",
+    "module": "dist/index.esm.js",
+    "types": "dist/index.d.ts",
+    "files": [
+        "dist/**/*"
+    ],
+    "author": "Antoni Kepinski <a@kepinski.me> (https://kepinski.me)",
+    "bugs": {
+        "url": "https://github.com/xxczaki/cashify/issues"
+    },
+    "scripts": {
+        "prebuild": "del-cli dist",
+        "esm": "tsc --module esnext && cpy dist/index.js dist --rename index.esm.js",
+        "cjs": "tsc --module commonjs",
+        "build": "npm run esm && npm run cjs",
+        "test": "xo && nyc ava",
+        "prepublishOnly": "npm run build"
+    },
+    "engines": {
+        "node": ">=10"
+    },
+    "license": "MIT",
+    "repository": "xxczaki/cashify",
+    "homepage": "https://github.com/xxczaki/cashify",
+    "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/cashify"
+    },
+    "keywords": [
+        "cashify",
+        "cash",
+        "moneyjs",
+        "money.js",
+        "money",
+        "conversion",
+        "exchange",
+        "currency-exchange",
+        "exchange-rates",
+        "open-exchange-rates",
+        "fixer",
+        "currencies",
+        "convert-currency-rates",
+        "replacement",
+        "convert-currencies",
+        "typescript",
+        "money-conversion"
+    ],
+    "devDependencies": {
+        "@akepinski/tsconfig": "0.0.2",
+        "@typescript-eslint/eslint-plugin": "^4.14.0",
+        "@typescript-eslint/parser": "^4.14.0",
+        "ava": "^3.15.0",
+        "coveralls": "^3.1.0",
+        "cpy-cli": "^3.1.1",
+        "del-cli": "^3.0.1",
+        "eslint-config-xo-typescript": "^0.37.0",
+        "nyc": "^15.1.0",
+        "ts-node": "^9.1.1",
+        "type-fest": "^0.20.2",
+        "typescript": "^4.1.3",
+        "xo": "^0.37.1"
+    },
+    "sideEffects": false,
+    "ava": {
+        "extensions": [
+            "ts"
+        ],
+        "require": [
+            "ts-node/register"
+        ]
+    },
+    "xo": {
+        "extends": "xo-typescript",
+        "extensions": [
+            "ts"
+        ]
+    },
+    "dependencies": {}
 }

--- a/src/cashify.ts
+++ b/src/cashify.ts
@@ -7,7 +7,7 @@ export default class Cashify {
 	* @constructor
 	* @param {Object} [options] Conversion options.
 	*/
-	constructor(public readonly options: Partial<Options>) { }
+	constructor(public readonly options: Partial<Options>) {}
 
 	/**
 	* Function, which converts currencies based on provided rates.

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -21,11 +21,6 @@ import parse from './utils/parser';
 export default function convert(amount: number | string, {from, to, base, rates}: Options): number {
 	// If provided `amount` is a string, use parsing
 	if (typeof amount === 'string') {
-        
-        // Don't bother parsing '0' - parse does not support it
-        if (amount.trim() === '0')
-            return 0;
-
 		const data = parse(amount);
 
 		return (data.amount * 100) * getRate(base, rates, data.from ?? from, data.to ?? to) / 100;

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -19,6 +19,7 @@ import parse from './utils/parser';
  * convert(10, {from: 'EUR', to: 'GBP', base: 'EUR', rates}); //=> 9.2
  */
 export default function convert(amount: number | string, {from, to, base, rates}: Options): number {
+	if (amount === '0') return 0;
 	// If provided `amount` is a string, use parsing
 	if (typeof amount === 'string') {
 		const data = parse(amount);

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -19,9 +19,13 @@ import parse from './utils/parser';
  * convert(10, {from: 'EUR', to: 'GBP', base: 'EUR', rates}); //=> 9.2
  */
 export default function convert(amount: number | string, {from, to, base, rates}: Options): number {
-	if (amount === '0') return 0;
 	// If provided `amount` is a string, use parsing
 	if (typeof amount === 'string') {
+        
+        // Don't bother parsing '0' - parse does not support it
+        if (amount.trim() === '0')
+            return 0;
+
 		const data = parse(amount);
 
 		return (data.amount * 100) * getRate(base, rates, data.from ?? from, data.to ?? to) / 100;

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -1,6 +1,4 @@
-export interface Rates {
-	[name: string]: number;
-}
+export type Rates = Record<string, number>;
 
 export interface Options {
 	/**

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -14,7 +14,7 @@ interface Options {
 * parse('10 EUR to GBP'); //=> {amount: 10, from: 'EUR', to: 'GBP'}
 */
 export default function parse(expression: string): Options {
-	const amount = Number.parseFloat(expression.replace(/[^\d-.]/g, '')) || undefined;
+	const amount = Number(expression.replace(/[^\d-.]/g, ''));
 	let from;
 	let to;
 
@@ -28,8 +28,8 @@ export default function parse(expression: string): Options {
 		from = expression.replace(/[^A-Za-z]/g, '');
 	}
 
-	if (amount === undefined) {
-		throw new Error('Could not parse the `amount` argument. Make sure it includes at least a valid amount.');
+	if (Number.isNaN(amount) || expression.trim().length === 0) {
+		throw new TypeError('Could not parse the `amount` argument. Make sure it includes at least a valid amount.');
 	}
 
 	return {

--- a/test/constructor.ts
+++ b/test/constructor.ts
@@ -35,6 +35,10 @@ test('accept `amount` of type `string`', t => {
 	t.is(cashify.convert('12', {from: 'USD', to: 'GBP'}), 9.857142857142856);
 });
 
+test('edge case: accept `amount` of type `string`, equal to 0', t => {
+	t.is(cashify.convert('0', {from: 'USD', to: 'GBP'}), 0);
+});
+
 test('`amount` equals 0', t => {
 	t.is(cashify.convert(0, {from: 'USD', to: 'GBP'}), 0);
 });
@@ -89,7 +93,7 @@ test('`rates` object does not contain either `from` or `to` currency', t => {
 test('parsing without a correct amount', t => {
 	const error = t.throws(() => {
 		cashify.convert('');
-	}, {instanceOf: Error});
+	}, {instanceOf: TypeError});
 
 	t.is(error.message, 'Could not parse the `amount` argument. Make sure it includes at least a valid amount.');
 });

--- a/test/function.ts
+++ b/test/function.ts
@@ -83,7 +83,7 @@ test('`rates` object does not contain either `from` or `to` currency', t => {
 test('parsing without a correct amount', t => {
 	const error = t.throws(() => {
 		convert('', {base: 'EUR', rates});
-	}, {instanceOf: Error});
+	}, {instanceOf: TypeError});
 
 	t.is(error.message, 'Could not parse the `amount` argument. Make sure it includes at least a valid amount.');
 });


### PR DESCRIPTION
The existing version throws:

```node
> // const rates = ...
> convert('0', {from: 'EUR', to: 'XFA', base: 'EUR', rates})
```
```
Uncaught:
Error: Could not parse the `amount` argument. Make sure it includes at least a valid amount.
    at Object.parse [as default] (C:\path\to\my\project\node_modules\cashify\dist\utils\parser.js:26:15)
    at convert (C:\path\to\my\project\node_modules\node_modules\cashify\dist\convert.js:28:38)
```